### PR TITLE
refactor: remove Facebook and Google authentication dependencies; streamline OAuth handling

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,20 +1,9 @@
-import java.util.Properties
-
 plugins {
     id("com.android.application")
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
-
-// Read Facebook keys from local.properties
-val localProperties = Properties()
-val localPropertiesFile = rootProject.file("local.properties")
-if (localPropertiesFile.exists()) {
-    localPropertiesFile.inputStream().use { localProperties.load(it) }
-}
-val fbAppId: String = localProperties.getProperty("FB_APP_ID", "")
-val fbClientToken: String = localProperties.getProperty("FB_CLIENT_TOKEN", "")
 
 android {
     namespace = "com.example.sponti"
@@ -39,11 +28,6 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
-
-        // Inject Facebook strings into R.string
-        resValue("string", "facebook_app_id", fbAppId)
-        resValue("string", "facebook_client_token", fbClientToken)
-        resValue("string", "fb_login_protocol_scheme", "fb$fbAppId")
     }
 
     buildTypes {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -42,29 +42,6 @@
             android:name="flutterEmbedding"
             android:value="2" />
 
-        <meta-data
-            android:name="com.facebook.sdk.ApplicationId"
-            android:value="@string/facebook_app_id"/>
-        <meta-data
-            android:name="com.facebook.sdk.ClientToken"
-            android:value="@string/facebook_client_token" />
-        <activity
-            android:name="com.facebook.FacebookActivity"
-            android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
-            android:label="@string/app_name" />
-
-        <activity
-            android:name="com.facebook.CustomTabActivity"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <!-- Replace with Facebook App ID prefixed with 'fb' -->
-                <data android:scheme="@string/fb_login_protocol_scheme" />
-            </intent-filter>
-        </activity>
-
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/docs/ENV_VARIABLES.md
+++ b/docs/ENV_VARIABLES.md
@@ -1,13 +1,13 @@
 # Environment Variables: Sponti
 
 **Purpose**: All secrets, API keys, and configuration needed for this project
-**Date**: 2026-03-08
+**Date**: 2026-03-12
 
 ---
 
 ## Development (.env.local)
 
-**File**: `.env.local` (local file, NOT committed to git — already in .gitignore)
+**File**: `.env.local` (local file, NOT committed to git - already in .gitignore)
 
 ```bash
 # Supabase
@@ -17,18 +17,10 @@ PUBLIC_SUPABASE_KEY=eyJhbG...your-anon-key...
 # Alternative names (app checks both)
 SUPABASE_URL=https://your-project-ref.supabase.co
 SUPABASE_KEY=eyJhbG...your-anon-key...
-
-# Google OAuth
-GOOGLE_SERVER_CLIENT_ID=your-google-server-client-id.apps.googleusercontent.com
-
-# Facebook OAuth (configured in AndroidManifest.xml / Info.plist, not env)
-# FACEBOOK_APP_ID=your-facebook-app-id
 ```
 
 **How to get these keys:**
-1. **Supabase URL + Anon Key**: https://supabase.com/dashboard → Your Project → Settings → API → Project URL + `anon public` key
-2. **Google Server Client ID**: https://console.cloud.google.com → APIs & Services → Credentials → OAuth 2.0 Client IDs → Web application client ID (used for `serverClientId`)
-3. **Facebook App ID**: https://developers.facebook.com → Your App → Settings → Basic → App ID (configured in native manifests, not .env)
+1. **Supabase URL + Anon Key**: https://supabase.com/dashboard -> Your Project -> Settings -> API -> Project URL + `anon public` key
 
 ---
 
@@ -38,9 +30,7 @@ GOOGLE_SERVER_CLIENT_ID=your-google-server-client-id.apps.googleusercontent.com
 |----------|------|-------|
 | `PUBLIC_SUPABASE_URL` / `SUPABASE_URL` | `.env.local` | Loaded via `flutter_dotenv` |
 | `PUBLIC_SUPABASE_KEY` / `SUPABASE_KEY` | `.env.local` | Supabase anon key (safe for client) |
-| `GOOGLE_SERVER_CLIENT_ID` | `.env.local` | Google OAuth server client ID |
-| Facebook App ID | `android/app/src/main/AndroidManifest.xml`, `ios/Runner/Info.plist` | Native config |
-| Google Services | `android/app/google-services.json`, `ios/Runner/GoogleService-Info.plist` | Firebase/Google config |
+| OAuth redirect scheme | `android/app/src/main/AndroidManifest.xml`, `ios/Runner/Info.plist` | Must match `io.supabase.sponti://login-callback/` |
 
 ---
 
@@ -48,9 +38,8 @@ GOOGLE_SERVER_CLIENT_ID=your-google-server-client-id.apps.googleusercontent.com
 
 | Variable | Required | Where Used | Notes |
 |----------|----------|------------|-------|
-| PUBLIC_SUPABASE_URL | Yes | `main.dart` → Supabase.initialize | Project URL |
-| PUBLIC_SUPABASE_KEY | Yes | `main.dart` → Supabase.initialize | Anon public key (safe for client) |
-| GOOGLE_SERVER_CLIENT_ID | Yes | `auth_remote_datasource.dart` | For Google Sign-In token exchange |
+| PUBLIC_SUPABASE_URL | Yes | `main.dart` -> Supabase.initialize | Project URL |
+| PUBLIC_SUPABASE_KEY | Yes | `main.dart` -> Supabase.initialize | Anon public key (safe for client) |
 
 ---
 
@@ -60,16 +49,14 @@ GOOGLE_SERVER_CLIENT_ID=your-google-server-client-id.apps.googleusercontent.com
 - [ ] Create `.env.local` in project root (copy template above)
 - [ ] Verify `.env.local` is in `.gitignore`
 - [ ] Get Supabase URL + anon key from Supabase dashboard
-- [ ] Get Google server client ID from Google Cloud Console
-- [ ] Configure Facebook App ID in AndroidManifest.xml
 - [ ] Run `flutter pub get`
 - [ ] Run `flutter run` to verify
 
 ### Production / Release Build
-- [ ] Use separate Supabase project for production
-- [ ] Use production Google OAuth client IDs
-- [ ] Use production Facebook App credentials
-- [ ] Ensure `.env.local` has production values OR use build-time env injection
+- [ ] Use a separate Supabase project for production
+- [ ] Configure Google/Facebook OAuth providers in Supabase dashboard
+- [ ] Ensure redirect URL list includes `io.supabase.sponti://login-callback/`
+- [ ] Ensure `.env.local` has production values or use build-time env injection
 
 ---
 
@@ -77,7 +64,6 @@ GOOGLE_SERVER_CLIENT_ID=your-google-server-client-id.apps.googleusercontent.com
 
 **Never commit:**
 - `.env.local` (contains Supabase keys)
-- `google-services.json` (if contains sensitive data)
 - Any file with actual secret values
 
 **Safe to commit:**
@@ -88,7 +74,6 @@ GOOGLE_SERVER_CLIENT_ID=your-google-server-client-id.apps.googleusercontent.com
 The anon key is designed to be public (used client-side). Security is enforced via Row Level Security (RLS) policies on the database, not by hiding the key. Never use the `service_role` key in the Flutter app.
 
 **If API keys are leaked:**
-1. Rotate Supabase API keys in dashboard → Settings → API
-2. Generate new Google OAuth client IDs
-3. Regenerate Facebook app secret
-4. Update `.env.local` with new values
+1. Rotate Supabase API keys in dashboard -> Settings -> API
+2. Rotate OAuth provider secrets in Supabase Authentication settings
+3. Update `.env.local` with new values

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -59,6 +59,14 @@
 			<string>com.googleusercontent.apps.861823949799-vc35cprkp249096uujjn0vvnmcvjppkn</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>io.supabase.sponti</string>
+			</array>
+		</dict>
 	</array>
 	<!-- End of the Google Sign-in Section -->
 </dict>

--- a/lib/features/auth/repository/auth_remote_data_source.dart
+++ b/lib/features/auth/repository/auth_remote_data_source.dart
@@ -1,8 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
-import 'package:google_sign_in/google_sign_in.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 abstract interface class AuthRemoteDataSource {
@@ -17,11 +14,7 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
   const AuthRemoteDataSourceImpl(this._client);
 
   final SupabaseClient _client;
-
-  static String get _googleServerClientId =>
-      dotenv.env['GOOGLE_SERVER_CLIENT_ID'] ?? '';
-
-  static bool _googleInitialized = false;
+  static const String _redirectTo = 'io.supabase.sponti://login-callback/';
 
   @override
   User? get currentUser => _client.auth.currentUser;
@@ -29,53 +22,34 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
   @override
   Stream<AuthState> get authStateChanges => _client.auth.onAuthStateChange;
 
-  Future<void> _ensureGoogleInitialized() async {
-    if (!_googleInitialized) {
-      await GoogleSignIn.instance.initialize(
-        serverClientId: _googleServerClientId,
-      );
-      _googleInitialized = true;
-    }
-  }
-
   @override
   Future<User> signInWithGoogle() async {
-    try {
-      await _ensureGoogleInitialized();
-
-      final googleUser = await GoogleSignIn.instance.authenticate();
-      final idToken = googleUser.authentication.idToken;
-      if (idToken == null) {
-        throw const AuthException('No ID token from Google.');
-      }
-
-      final response = await _client.auth.signInWithIdToken(
-        provider: OAuthProvider.google,
-        idToken: idToken,
-      );
-
-      final user = response.user;
-      if (user == null) {
-        throw const AuthException(
-          'Google sign-in failed: No user returned from Supabase.',
-        );
-      }
-      return user;
-    } catch (e) {
-      throw AuthException(e.toString());
-    }
+    return _signInWithOAuth(
+      provider: OAuthProvider.google,
+      providerLabel: 'Google',
+    );
   }
 
   @override
   Future<User> signInWithFacebook() async {
+    return _signInWithOAuth(
+      provider: OAuthProvider.facebook,
+      providerLabel: 'Facebook',
+    );
+  }
+
+  Future<User> _signInWithOAuth({
+    required OAuthProvider provider,
+    required String providerLabel,
+  }) async {
     try {
       final success = await _client.auth.signInWithOAuth(
-        OAuthProvider.facebook,
-        redirectTo: 'io.supabase.sponti://login-callback/',
+        provider,
+        redirectTo: _redirectTo,
       );
 
       if (!success) {
-        throw const AuthException('Facebook sign-in failed to launch.');
+        throw AuthException('$providerLabel sign-in failed to launch.');
       }
 
       final authState = await _client.auth.onAuthStateChange
@@ -83,7 +57,9 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
           .timeout(const Duration(minutes: 2));
 
       final user = authState.session?.user;
-      if (user == null) throw const AuthException('Facebook sign-in failed.');
+      if (user == null) {
+        throw AuthException('$providerLabel sign-in failed.');
+      }
       return user;
     } catch (e) {
       throw AuthException(e.toString());
@@ -93,13 +69,5 @@ class AuthRemoteDataSourceImpl implements AuthRemoteDataSource {
   @override
   Future<void> signOut() async {
     await _client.auth.signOut(scope: SignOutScope.local);
-
-    try {
-      await _ensureGoogleInitialized();
-      await GoogleSignIn.instance.signOut();
-    } catch (_) {}
-    try {
-      await FacebookAuth.instance.logOut();
-    } catch (_) {}
   }
 }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,7 +7,6 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_linux/file_selector_plugin.h>
-#include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <gtk/gtk_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
@@ -15,9 +14,6 @@ void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
-  g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
-  flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);
   g_autoptr(FlPluginRegistrar) gtk_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
   gtk_plugin_register_with_registrar(gtk_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,7 +4,6 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
-  flutter_secure_storage_linux
   gtk
   url_launcher_linux
 )

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,11 +7,8 @@ import Foundation
 
 import app_links
 import connectivity_plus
-import facebook_auth_desktop
 import file_selector_macos
-import flutter_secure_storage_macos
 import geolocator_apple
-import google_sign_in_ios
 import package_info_plus
 import share_plus
 import shared_preferences_foundation
@@ -22,11 +19,8 @@ import video_player_avfoundation
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
-  FacebookAuthDesktopPlugin.register(with: registry.registrar(forPlugin: "FacebookAuthDesktopPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
-  FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
-  FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -361,14 +361,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.8"
-  facebook_auth_desktop:
-    dependency: transitive
-    description:
-      name: facebook_auth_desktop
-      sha256: "219d559a33891e937c1913430505eae01fb946cb35729167bbdc747e3ebbd9ff"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.1"
   fake_async:
     dependency: transitive
     description:
@@ -454,30 +446,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.0.0"
-  flutter_facebook_auth:
-    dependency: "direct main"
-    description:
-      name: flutter_facebook_auth
-      sha256: f4652480123fa22d02c8fd3cb890246bf3358d1e9928fc5f576c3d1b0faf2acc
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.1.5"
-  flutter_facebook_auth_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_facebook_auth_platform_interface
-      sha256: e04b8dbfa77702bea45a79993163ad5d20b2c0084109bec591fdc2b9ee505779
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.2"
-  flutter_facebook_auth_web:
-    dependency: transitive
-    description:
-      name: flutter_facebook_auth_web
-      sha256: f682400d61cf8d52dd8b6458b5ee106ed57e95309a117dc32875d3da129ce47c
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.2"
   flutter_lints:
     dependency: "direct dev"
     description:
@@ -510,54 +478,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
-  flutter_secure_storage:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage
-      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.2.4"
-  flutter_secure_storage_linux:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_linux
-      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.3"
-  flutter_secure_storage_macos:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_macos
-      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
-  flutter_secure_storage_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_platform_interface
-      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.2"
-  flutter_secure_storage_web:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_web
-      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.1"
-  flutter_secure_storage_windows:
-    dependency: transitive
-    description:
-      name: flutter_secure_storage_windows
-      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.2"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -728,54 +648,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "17.1.0"
-  google_identity_services_web:
-    dependency: transitive
-    description:
-      name: google_identity_services_web
-      sha256: "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.3.3+1"
-  google_sign_in:
-    dependency: "direct main"
-    description:
-      name: google_sign_in
-      sha256: "521031b65853b4409b8213c0387d57edaad7e2a949ce6dea0d8b2afc9cb29763"
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.2.0"
-  google_sign_in_android:
-    dependency: transitive
-    description:
-      name: google_sign_in_android
-      sha256: f353140580797e01c1f35748810326f326664c52040b6f62d88e7d6d1cd30917
-      url: "https://pub.dev"
-    source: hosted
-    version: "7.2.9"
-  google_sign_in_ios:
-    dependency: transitive
-    description:
-      name: google_sign_in_ios
-      sha256: ac1e4c1205267cb7999d1d81333fccffdfda29e853f434bbaf71525498bb6950
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.3.0"
-  google_sign_in_platform_interface:
-    dependency: transitive
-    description:
-      name: google_sign_in_platform_interface
-      sha256: "7f59208c42b415a3cca203571128d6f84f885fead2d5b53eb65a9e27f2965bb5"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
-  google_sign_in_web:
-    dependency: transitive
-    description:
-      name: google_sign_in_web
-      sha256: dac0676af14b96b11691cc3c3e152415a896a38f1224269241d7cc294bdb9102
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.2"
   gotrue:
     dependency: transitive
     description:
@@ -968,14 +840,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,8 +39,6 @@ dependencies:
   supabase_flutter: ^2.12.0 
 
   # Authentication
-  google_sign_in: ^7.2.0
-  flutter_facebook_auth: ^7.1.5
 
   # Location & Permissions
   geolocator: ^14.0.2 # GPS coordinates, distance calculation

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -9,7 +9,6 @@
 #include <app_links/app_links_plugin_c_api.h>
 #include <connectivity_plus/connectivity_plus_windows_plugin.h>
 #include <file_selector_windows/file_selector_windows.h>
-#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <geolocator_windows/geolocator_windows.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
@@ -22,8 +21,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("ConnectivityPlusWindowsPlugin"));
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
-  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   GeolocatorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("GeolocatorWindows"));
   PermissionHandlerWindowsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -6,7 +6,6 @@ list(APPEND FLUTTER_PLUGIN_LIST
   app_links
   connectivity_plus
   file_selector_windows
-  flutter_secure_storage_windows
   geolocator_windows
   permission_handler_windows
   share_plus


### PR DESCRIPTION
## Summary by Sourcery

Remove native Facebook/Google SDK authentication in favor of Supabase-hosted OAuth flows and consolidate third-party sign-in handling.

New Features:
- Support a shared OAuth sign-in flow for multiple providers using Supabase auth state callbacks.

Enhancements:
- Refactor Google and Facebook sign-in to use a common OAuth helper with provider-specific labels.
- Centralize the OAuth redirect URI as a constant and wire it into platform URL scheme configuration.
- Simplify sign-out logic to rely solely on Supabase session management without calling native SDK logout methods.

Build:
- Remove Facebook-specific Gradle configuration and resource injection from the Android build.
- Drop Google/Facebook auth dependencies from the Flutter project and clean up related plugin registrations across platforms.

Deployment:
- Update Android and iOS platform configuration to remove Facebook integration and register the Supabase OAuth redirect scheme.

Documentation:
- Update environment variable documentation to remove Google/Facebook client ID requirements and clarify Supabase OAuth redirect configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * Removed Facebook authentication support
  * Removed secure storage plugin from Linux, macOS, and Windows platforms

* **Chores**
  * Removed Google Sign-In and Facebook Auth dependencies
  * Refactored OAuth sign-in to use a unified flow via Supabase
  * Updated iOS configuration for Supabase URL scheme

* **Documentation**
  * Updated environment variables documentation with current OAuth setup guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->