### PR TITLE
Add favorite toggle to map location cards

### DIFF
--- a/lib/features/locations/view/screens/location_screen.dart
+++ b/lib/features/locations/view/screens/location_screen.dart
@@ -48,6 +48,10 @@ class _LocationScreenState extends ConsumerState<LocationScreen> {
     setState(() => _isRailExpanded = expanded);
   }
 
+  Future<void> _handleFavoriteTap(Location location) async {
+    await ref.read(favoriteIdsProvider.notifier).toggle(location.id);
+  }
+
   @override
   Widget build(BuildContext context) {
     final locationsAsync = ref.watch(locationsProvider);
@@ -192,11 +196,13 @@ class _LocationScreenState extends ConsumerState<LocationScreen> {
             selectedCategory: filter.selectedCategory,
             isExpanded: _isRailExpanded,
             bottomInset: bottomInset,
+            favoriteIds: favoriteIds,
             onExpandChanged: _setRailExpanded,
             onTapCategory: _onTapCategory,
             onTapLocation: (location) {
               context.push(RouteName.locationDetailPath(location.id));
             },
+            onTapFavorite: _handleFavoriteTap,
           ),
         ],
       ),

--- a/lib/features/locations/view/widgets/bottom_rail_panel.dart
+++ b/lib/features/locations/view/widgets/bottom_rail_panel.dart
@@ -17,6 +17,8 @@ class BottomRailPanel extends StatefulWidget {
     required this.onExpandChanged,
     required this.onTapCategory,
     required this.onTapLocation,
+    required this.favoriteIds,
+    required this.onTapFavorite,
   });
 
   final List<Location> locations;
@@ -27,6 +29,8 @@ class BottomRailPanel extends StatefulWidget {
   final ValueChanged<bool> onExpandChanged;
   final ValueChanged<LocationCategory> onTapCategory;
   final ValueChanged<Location> onTapLocation;
+  final Set<String> favoriteIds;
+  final ValueChanged<Location> onTapFavorite;
 
   @override
   State<BottomRailPanel> createState() => _BottomRailPanelState();
@@ -194,8 +198,15 @@ class _BottomRailPanelState extends State<BottomRailPanel> {
                                     child: LocationCard(
                                       location: location,
                                       width: 200,
+                                      isSaved: widget.favoriteIds.contains(
+                                        location.id,
+                                      ),
                                       onTap: () =>
                                           widget.onTapLocation(location),
+                                      onSaveToggle: () =>
+                                          widget.onTapFavorite(location),
+                                      savedIcon: Icons.favorite_border_rounded,
+                                      savedActiveIcon: Icons.favorite_rounded,
                                     ),
                                   );
                                 },

--- a/lib/features/locations/view/widgets/location_card.dart
+++ b/lib/features/locations/view/widgets/location_card.dart
@@ -14,12 +14,20 @@ class LocationCard extends StatelessWidget {
     this.variant = LocationCardVariant.compact,
     this.width = 220,
     this.onTap,
+    this.isSaved = false,
+    this.onSaveToggle,
+    this.savedIcon = Icons.bookmark_outline_rounded,
+    this.savedActiveIcon = Icons.bookmark_rounded,
   });
 
   final Location location;
   final LocationCardVariant variant;
   final double width;
   final VoidCallback? onTap;
+  final bool isSaved;
+  final VoidCallback? onSaveToggle;
+  final IconData savedIcon;
+  final IconData savedActiveIcon;
 
   bool get _isFullWidth => variant == LocationCardVariant.fullWidth;
 
@@ -46,7 +54,13 @@ class LocationCard extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: [
-              _CardImage(location: location),
+              _CardImage(
+                location: location,
+                isSaved: isSaved,
+                onSaveToggle: onSaveToggle,
+                savedIcon: savedIcon,
+                savedActiveIcon: savedActiveIcon,
+              ),
               _CardBody(location: location),
             ],
           ),
@@ -57,9 +71,19 @@ class LocationCard extends StatelessWidget {
 }
 
 class _CardImage extends StatelessWidget {
-  const _CardImage({required this.location});
+  const _CardImage({
+    required this.location,
+    required this.isSaved,
+    required this.onSaveToggle,
+    required this.savedIcon,
+    required this.savedActiveIcon,
+  });
 
   final Location location;
+  final bool isSaved;
+  final VoidCallback? onSaveToggle;
+  final IconData savedIcon;
+  final IconData savedActiveIcon;
 
   @override
   Widget build(BuildContext context) {
@@ -137,7 +161,7 @@ class _CardImage extends StatelessWidget {
           if (location.isHiddenGem)
             Positioned(
               top: 8,
-              right: 8,
+              right: onSaveToggle == null ? 8 : 48,
               child: Container(
                 padding: const EdgeInsets.all(5),
                 decoration: BoxDecoration(
@@ -148,6 +172,30 @@ class _CardImage extends StatelessWidget {
                   Icons.auto_awesome_rounded,
                   size: 12,
                   color: SpontiColors.accent,
+                ),
+              ),
+            ),
+
+          if (onSaveToggle != null)
+            Positioned(
+              top: 8,
+              right: 8,
+              child: Material(
+                color: Colors.white.withValues(alpha: 0.92),
+                shape: const CircleBorder(),
+                child: InkWell(
+                  customBorder: const CircleBorder(),
+                  onTap: onSaveToggle,
+                  child: Padding(
+                    padding: const EdgeInsets.all(6),
+                    child: Icon(
+                      isSaved ? savedActiveIcon : savedIcon,
+                      size: 16,
+                      color: isSaved
+                          ? SpontiColors.primary
+                          : SpontiColors.textSecondary,
+                    ),
+                  ),
                 ),
               ),
             ),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -2,11 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sponti/core/theme/app_theme.dart';
-import 'package:sponti/features/favorites/favorites_viewmodel.dart';
 import 'package:sponti/features/favorites/view/screens/favorites_screen.dart';
+import 'package:sponti/features/favorites/viewmodel/favorites_viewmodel.dart';
 import 'package:sponti/features/locations/model/coordinates.dart';
 import 'package:sponti/features/locations/model/location.dart';
-import 'package:sponti/features/locations/viewmodel/location_viewmodel.dart';
 
 void main() {
   testWidgets('shows empty state when there are no saved places', (
@@ -19,7 +18,14 @@ void main() {
       ProviderScope(
         overrides: [
           favoriteIdsProvider.overrideWith(TestFavoritesViewModel.new),
-          locationsProvider.overrideWith(TestLocationsViewModel.new),
+          favoriteLocationsProvider.overrideWith(
+            (ref) async {
+              final ids = await ref.watch(favoriteIdsProvider.future);
+              return testLocations
+                  .where((location) => ids.contains(location.id))
+                  .toList(growable: false);
+            },
+          ),
         ],
         child: const _TestApp(child: FavoritesScreen()),
       ),
@@ -53,7 +59,14 @@ void main() {
       ProviderScope(
         overrides: [
           favoriteIdsProvider.overrideWith(TestFavoritesViewModel.new),
-          locationsProvider.overrideWith(TestLocationsViewModel.new),
+          favoriteLocationsProvider.overrideWith(
+            (ref) async {
+              final ids = await ref.watch(favoriteIdsProvider.future);
+              return testLocations
+                  .where((location) => ids.contains(location.id))
+                  .toList(growable: false);
+            },
+          ),
         ],
         child: const _TestApp(child: FavoritesScreen()),
       ),
@@ -99,11 +112,6 @@ class TestFavoritesViewModel extends FavoritesViewModel {
     }
     state = AsyncData(updated);
   }
-}
-
-class TestLocationsViewModel extends LocationsViewModel {
-  @override
-  Future<List<Location>> build() async => [...testLocations];
 }
 
 class _TestApp extends StatelessWidget {


### PR DESCRIPTION
huhu

## Summary by Sourcery

Add favorite toggle support to location cards and wire it into the map bottom rail and favorites flow.

New Features:
- Allow location cards to display a configurable saved/favorite toggle icon overlay.
- Support passing favorite state and toggle callbacks from the bottom rail panel into individual location cards.

Enhancements:
- Adjust hidden gem badge positioning to coexist with an optional favorite toggle button in location card images.
- Update favorites widget tests to use the favoriteLocationsProvider instead of a locations view model stub.

Tests:
- Adapt favorites screen widget tests to the new favorites provider setup and test data flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now save locations as favorites directly from location cards.
  * Save buttons appear on location card images with visual feedback indicating saved status.
  * Favorite locations are tracked and managed within the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->